### PR TITLE
fix PDF link in README for example content

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ typst init @preview/tgm-hit-protocol
 
 ## Usage
 
-The template ([rendered PDF](example.pdf)) contains thesis writing advice (in German) as example content. If you are looking for the details of this template package's function, take a look at the [manual](docs/manual.pdf).
+The template ([rendered PDF](example.pdf)) contains protocol writing advice (in German) as example content. If you are looking for the details of this template package's function, take a look at the [manual](docs/manual.pdf).

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ typst init @preview/tgm-hit-protocol
 
 ## Usage
 
-The template ([rendered PDF](main.pdf)) contains thesis writing advice (in German) as example content. If you are looking for the details of this template package's function, take a look at the [manual](docs/manual.pdf).
+The template ([rendered PDF](example.pdf)) contains thesis writing advice (in German) as example content. If you are looking for the details of this template package's function, take a look at the [manual](docs/manual.pdf).


### PR DESCRIPTION
Cooles protocoll, aber der Link im README war nicht ganz richtig, ich hab ihn mal ausgetauscht mit example.pdf, weil das am naheliegendsten war. 